### PR TITLE
Add named map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ cross-platform Rust API for memory-mapped file IO.
 - [x] synchronous and asynchrounous flushing
 - [x] copy-on-write memory maps
 - [x] read-only memory maps
+- [x] named memory maps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,9 @@ impl Protection {
 /// A file-backed `Mmap` buffer may be used to read or write data to a file. Use `Mmap::open(..)` to
 /// create a file-backed memory map. An anonymous `Mmap` buffer may be used any place that an
 /// in-memory byte buffer is needed, and gives the added features of a memory map. Use
-/// `Mmap::anonymous(..)` to create an anonymous memory map.
+/// `Mmap::anonymous(..)` to create an anonymous memory map. A named `Mmap` buffer may be used
+/// wherever a memory map is needed between processes or just for easier referencing. Use
+/// `Mmap::named(..)` to create a named memory map.
 ///
 /// Changes written to a memory-mapped file are not guaranteed to be durable until the memory map is
 /// flushed, or it is dropped.
@@ -102,6 +104,14 @@ impl Protection {
 /// let mut anon_mmap = Mmap::anonymous(4096, Protection::ReadWrite).unwrap();
 /// (&mut *anon_mmap).write(b"foo").unwrap();
 /// assert_eq!(b"foo\0\0", &anon_mmap[0..5]);
+///
+/// let mut named_mmap1 = Mmap::named(4096, Protection::ReadWrite,
+///                                   "example_map".to_string(), true).unwrap();
+/// // Open a map with the same name
+/// let mut named_mmap2 = Mmap::named(4096, Protection::ReadWrite,
+///                                   "example_map".to_string(), false).unwrap();
+/// (&mut *named_mmap1).write(b"foo").unwrap(); // Write into first map
+/// assert_eq!(b"foo\0\0", &named_mmap2[0..5]); // Read from second map
 /// ```
 pub struct Mmap {
     inner: MmapInner

--- a/src/posix.rs
+++ b/src/posix.rs
@@ -1,6 +1,7 @@
 use std::{self, io, ptr, slice};
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
+use std::ffi::CString;
 
 use libc;
 
@@ -24,11 +25,20 @@ impl Protection {
             Protection::ReadCopy => libc::MAP_PRIVATE,
         }
     }
+
+    fn as_mode(self) -> libc::mode_t {
+        match self {
+            Protection::Read => 0o400,
+            Protection::ReadWrite => 0o600,
+            Protection::ReadCopy => 0o600,
+        }
+    }
 }
 
 pub struct MmapInner {
     ptr: *mut libc::c_void,
     len: usize,
+    shm: Option<(libc::c_int, String)>,
 }
 
 impl MmapInner {
@@ -53,6 +63,7 @@ impl MmapInner {
             Ok(MmapInner {
                 ptr: ptr,
                 len: len as usize,
+                shm: None,
             })
         }
     }
@@ -74,6 +85,52 @@ impl MmapInner {
             Ok(MmapInner {
                 ptr: ptr,
                 len: len as usize,
+                shm: None,
+            })
+        }
+    }
+
+    /// Open an named memory map.
+    ///
+    /// If `exclusive` is true, this method will return an error if a map with the same name
+    /// already exists. The specified name must not contain any forward or backwards slashes.
+    pub fn named(len: usize, prot: Protection, name: String, exclusive: bool) -> io::Result<MmapInner> {
+        // Adds a forward slash to work with shm_open in POSIX systems.
+        let name = format!("/{}", name);
+
+        // Create a shared memory object. By default this will create a new object if the specified
+        // name does not already exist.
+        let fd = unsafe {
+            libc::shm_open(CString::new(name.clone()).unwrap().as_ptr(),
+                           libc::O_CREAT
+                           | if let Protection::Read = prot { libc::O_RDONLY } else { libc::O_RDWR }
+                           | if exclusive { libc::O_EXCL } else { 0 },
+                           prot.as_mode())
+        };
+
+        if fd == -1 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Truncate shared memory object to specified size.
+        unsafe { libc::ftruncate(fd, len as libc::off_t) };
+
+        let ptr = unsafe {
+            libc::mmap(ptr::null_mut(),
+                       len as libc::size_t,
+                       prot.as_prot(),
+                       prot.as_flag(),
+                       fd,
+                       0)
+        };
+
+        if ptr == libc::MAP_FAILED {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(MmapInner {
+                ptr: ptr,
+                len: len as usize,
+                shm: Some((fd, name)),
             })
         }
     }
@@ -107,6 +164,23 @@ impl Drop for MmapInner {
         unsafe {
             assert!(libc::munmap(self.ptr, self.len as libc::size_t) == 0,
                     "unable to unmap mmap: {}", io::Error::last_os_error());
+
+            // If there is an attached shared memory object,
+            if let Some(ref shm) = self.shm {
+                // Close the file descriptor and
+                assert!(libc::close(shm.0) == 0, "unable to close shm fd: {}",
+                        io::Error::last_os_error());
+
+                // Unlink the shared memory object.
+                let unlink = libc::shm_unlink(CString::new(shm.1.clone()).unwrap().as_ptr()) == 0;
+                let enoent = io::Error::last_os_error().raw_os_error().unwrap() == libc::ENOENT;
+
+                // Asserts that either the unlink was successful or there was no object with the
+                // associated name, meaning a matching named Mmap was destroyed earlier.
+                assert!(unlink || enoent,
+                        "unable to unlink shm object: {}",
+                        io::Error::last_os_error());
+            }
         }
     }
 }


### PR DESCRIPTION
This should make it possible to share maps between processes. On POSIX systems, the shared memory segment is unlinked when the first map is dropped, maybe there could be a way of keeping track of how many maps are open?
