### PR TITLE
Overhaul the API

### DIFF
--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -2,15 +2,17 @@ extern crate memmap;
 
 use std::env;
 use std::io::{self, Write};
-
-use memmap::{Mmap, Protection};
+use std::fs::File;
 
 /// Output a file's contents to stdout. The file path must be provided as the first process
 /// argument.
 fn main() {
     let path = env::args().nth(1).expect("supply a single path as the program argument");
 
-    let mmap = Mmap::open_path(path, Protection::Read).unwrap();
+    let file = File::open(path).expect("failed to open the file");
 
-    io::stdout().write_all(unsafe { mmap.as_slice() }).unwrap();
+    let mmap = unsafe { memmap::file(&file) }
+            .map().expect("failed to map the file");
+
+    io::stdout().write_all(&mmap[..]).expect("failed to output the file contents");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,25 +14,26 @@ mod unix;
 use unix::MmapInner;
 
 use std::fmt;
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{Error, ErrorKind, Result};
-use std::path::Path;
 use std::slice;
 use std::usize;
+use std::ops::{Deref, DerefMut};
 
 /// Memory map protection.
 ///
 /// Determines how a memory map may be used. If the memory map is backed by a
 /// file, then the file must have permissions corresponding to the operations
 /// the protection level allows.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Protection {
 
-    /// A read-only memory map. Writes to the memory map will result in a panic.
+    /// A read-only memory map.
     Read,
 
     /// A read-write memory map. Writes to the memory map will be reflected in
-    /// the file after a call to `Mmap::flush` or after the `Mmap` is dropped.
+    /// the file after a call to [`MmapMut::flush`](struct.MmapMut.html#method.flush)
+    /// or after the `MmapMut` is dropped.
     ReadWrite,
 
     /// A read, copy-on-write memory map. Writes to the memory map will not be
@@ -45,115 +46,300 @@ pub enum Protection {
     ReadExecute,
 }
 
-impl Protection {
+// Anonymous mappings
 
-    fn as_open_options(self) -> fs::OpenOptions {
-        let mut options = fs::OpenOptions::new();
-        options.read(true)
-               .write(self == Protection::ReadWrite ||
-                      (self == Protection::ReadCopy && MmapInner::needs_write_for_copy()));
+/// Options that can be used to configure how an anonymous mapping is created.
+///
+/// Create this structure by calling [`memmap::anonymous()`](fn.anonymous.html),
+/// then chain call methods to configure additional options, finally, call [`map()`](#method.map)
+/// or [`map_mut()`](#method.map_mut).
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct AnonymousMmapOptions {
+    protection: Option<Protection>,
+    len: usize,
+    stack: bool,
+}
 
-        options
-    }
-
-    /// Returns `true` if the `Protection` is writable.
-    pub fn write(self) -> bool {
-        self == Protection::ReadWrite || self == Protection::ReadCopy
+/// Configure a new anonymous mapping of `len` bytes.
+pub fn anonymous(len: usize) -> AnonymousMmapOptions {
+    AnonymousMmapOptions {
+        protection: None,
+        len,
+        stack: false,
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct MmapOptions {
-    /// Indicates that the memory map should be suitable for a stack.
+impl AnonymousMmapOptions {
+    /// Make this mapping suitable to be a process or thread stack.
     ///
-    /// This option should only be used with anonymous memory maps.
-    pub stack: bool,
+    /// This corresponds to `MAP_STACK` on Linux, which is currently a no-op.
+    pub fn stack(&mut self) -> &mut Self {
+        self.stack = true;
+        self
+    }
+
+    /// Set a protection to be used by this mapping.
+    pub fn protection(&mut self, protection: Protection) -> &mut Self {
+        self.protection = Some(protection);
+        self
+    }
+
+    fn map_inner(&self) -> Result<MmapInner> {
+        let inner = MmapInner::anonymous(self.len, self.protection.unwrap(), self.stack)?;
+        Ok(inner)
+    }
+
+    /// Actually map this anonymous mapping into the address space.
+    ///
+    /// If the protection has not been [set explicitly](#method.protection), this method
+    /// assumes [`ReadWrite`](enum.Protection.html#variant.ReadWrite).
+    ///
+    /// # Errors
+    ///
+    /// This method returns `Err` when the underlying system call fails, which can happen for
+    /// a variety of reasons, such as when you don't have the necessary permissions for the file.
+    ///
+    /// This method *also* returns `Err` with `ErrorKind` set to `InvalidInput` if the specified
+    /// protection does not allow the mapping to be mutable.
+    pub fn map_mut(&self) -> Result<MmapMut> {
+        let mut this = *self;
+        if this.protection.is_none() {
+            this.protection = Some(Protection::ReadWrite);
+        }
+        match this.protection.unwrap() {
+            Protection::Read | Protection::ReadExecute => Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Invalid protection for a mutable mapping",
+            )),
+            Protection::ReadWrite | Protection::ReadCopy => {
+                let inner = this.map_inner()?;
+                Ok( MmapMut { inner } )
+            }
+        }
+    }
 }
 
-/// A memory-mapped buffer.
+// File-backed mappings
+
+/// Options that can be used to configure how a file-backed mapping is created.
+///
+/// Create this structure by calling [`memmap::file()`](fn.file.html),
+/// then chain call methods to configure additional options, finally, call [`map()`](#method.map)
+/// or [`map_mut()`](#method.map_mut).
+#[derive(Copy, Clone, Debug)]
+pub struct FileMmapOptions<'a> {
+    file: &'a File,
+    protection: Option<Protection>,
+    offset: usize,
+    len: Option<usize>,
+}
+
+/// Configure a new file-backed mapping.
+///
+/// # Unsafety
+///
+/// This function is `unsafe`, because it's up to the caller to ensure
+/// that no other process or thread is accessing the same file concurrently.
+/// In particular, it is **undefined behavior** in Rust for the memory to be
+/// modified by some other code while there's a reference to it.
+pub unsafe fn file(file: &File) -> FileMmapOptions {
+    FileMmapOptions {
+        file,
+        protection: None,
+        offset: 0,
+        len: None,
+    }
+}
+
+impl<'a> FileMmapOptions<'a> {
+    /// Configure this mapping to start at byte `offset` from the beginning of the file.
+    pub fn offset(&mut self, offset: usize) -> &mut Self {
+        self.offset = offset;
+        self
+    }
+    /// Configure this mapping to be `len` bytes long.
+    pub fn len(&mut self, len: usize) -> &mut Self {
+        self.len = Some(len);
+        self
+    }
+    /// Set a protection to be used by this mapping.
+    pub fn protection(&mut self, protection: Protection) -> &mut Self {
+        self.protection = Some(protection);
+        self
+    }
+
+    fn map_inner(&self) -> Result<MmapInner> {
+        let len;
+        if let Some(l) = self.len {
+            len = l;
+        } else {
+            let l = self.file.metadata()?.len();
+            if l > usize::MAX as u64 {
+                return Err(Error::new(ErrorKind::InvalidData,
+                      "file length overflows usize"));
+            }
+            len = l as usize - self.offset;
+        }
+        let inner = MmapInner::open(self.file, self.protection.unwrap(), self.offset, len)?;
+        Ok(inner)
+    }
+
+    /// Actually map this mapping into the address space.
+    ///
+    /// This method returns an immutable mapping, see [`map_mut()`](#method.map_mut)
+    /// for a mutable version.
+    ///
+    /// If the protection has not been [set explicitly](#method.protection), this method
+    /// assumes [`Read`](enum.Protection.html#variant.Read).
+    ///
+    /// # Errors
+    ///
+    /// This method returns `Err` when the underlying system call fails, which can happen for
+    /// a variety of reasons, such as when you don't have the necessary permissions for the file.
+    pub fn map(&self) -> Result<Mmap> {
+        let mut this = *self;
+        if this.protection.is_none() {
+            this.protection = Some(Protection::Read);
+        }
+        let inner = this.map_inner()?;
+        Ok( Mmap { inner } )
+    }
+
+    /// Actually map this mapping into the address space.
+    ///
+    /// This method returns a mutable mapping, see [`map()`](#method.map) for an immutable
+    /// version.
+    ///
+    /// If the protection has not been [set explicitly](#method.protection), this method
+    /// assumes [`ReadWrite`](enum.Protection.html#variant.ReadWrite).
+    ///
+    /// # Errors
+    ///
+    /// This method returns `Err` when the underlying system call fails, which can happen for
+    /// a variety of reasons, such as when you don't have the necessary permissions for the file.
+    ///
+    /// This method *also* returns `Err` with `ErrorKind` set to `InvalidInput` if the specified
+    /// protection does not allow the mapping to be mutable.
+    pub fn map_mut(&self) -> Result<MmapMut> {
+        let mut this = *self;
+        if this.protection.is_none() {
+            this.protection = Some(Protection::ReadWrite);
+        }
+        match this.protection.unwrap() {
+            Protection::Read | Protection::ReadExecute => Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Invalid protection for a mutable mapping",
+            )),
+            Protection::ReadWrite | Protection::ReadCopy => {
+                let inner = this.map_inner()?;
+                Ok( MmapMut { inner } )
+            }
+        }
+    }
+}
+
+/// An immutable memory-mapped buffer.
 ///
 /// A file-backed `Mmap` buffer may be used to read or write data to a file. Use
-/// `Mmap::open(..)` to create a file-backed memory map. An anonymous `Mmap`
-/// buffer may be used any place that an in-memory byte buffer is needed, and
-/// gives the added features of a memory map. Use `Mmap::anonymous(..)` to
-/// create an anonymous memory map.
-///
-/// Changes written to a memory-mapped file are not guaranteed to be durable
-/// until the memory map is flushed, or it is dropped.
+/// [`memmap::file(..)`](fn.file.html)`.map()` to create a file-backed memory map, or
+/// [`memmap::anonymous(..)`](fn.anonymous.html)`.map()` to create an anonymous memory map.
 ///
 /// ```
 /// use std::io::Write;
-/// use memmap::{Mmap, Protection};
+/// use std::fs::File;
 ///
-/// let file_mmap = Mmap::open_path("README.md", Protection::Read).unwrap();
-/// let bytes: &[u8] = unsafe { file_mmap.as_slice() };
-/// assert_eq!(b"# memmap", &bytes[0..8]);
-///
-/// let mut anon_mmap = Mmap::anonymous(4096, Protection::ReadWrite).unwrap();
-/// unsafe { anon_mmap.as_mut_slice() }.write(b"foo").unwrap();
-/// assert_eq!(b"foo\0\0", unsafe { &anon_mmap.as_slice()[0..5] });
+/// let file = File::open("README.md").unwrap();
+/// let mmap = unsafe { memmap::file(&file).map().unwrap() };
+/// assert_eq!(b"# memmap", &mmap[0..8]);
 /// ```
+///
+/// See [`MmapMut`](struct.MmapMut.html) for the mutable version.
 pub struct Mmap {
     inner: MmapInner
 }
 
 impl Mmap {
-
-    /// Opens a file-backed memory map.
+    /// Change the `Protection` this mapping was created with.
     ///
-    /// The file must be opened with read permissions, and write permissions if
-    /// the supplied protection is `ReadWrite`. The file must not be empty.
-    pub fn open(file: &File, prot: Protection) -> Result<Mmap> {
-        let len = try!(file.metadata()).len();
-        if len > usize::MAX as u64 {
-            return Err(Error::new(ErrorKind::InvalidData,
-                                  "file length overflows usize"));
+    /// This method only changes the protection of the underlying mapping,
+    /// but it doesn't make an `MmapMut` from an `Mmap`, use [`make_mut()`](#method.make_mut)
+    /// method for that.
+    ///
+    /// If you create a read-only file-backed mapping, you can **not** use this method to make the
+    /// mapping writeable. Remap the file instead.
+    ///
+    /// # Errors
+    ///
+    /// This method returns `Err` when the underlying system call fails, which can happen for
+    /// a variety of reasons, such as when you don't have the necessary permissions for the file.
+    pub fn set_protection(&mut self, protection: Protection) -> Result<()> {
+        self.inner.set_protection(protection)
+    }
+
+    /// Change the `Protection` this mapping was created with to make it mutable.
+    ///
+    /// If you create a read-only file-backed mapping, you can **not** use this method to make the
+    /// mapping writeable. Remap the file instead.
+    ///
+    /// # Errors
+    ///
+    /// This method returns `Err` when the underlying system call fails, which can happen for
+    /// a variety of reasons, such as when you don't have the necessary permissions for the file.
+    ///
+    /// This method *also* returns `Err` with `ErrorKind` set to `InvalidInput` if the specified
+    /// protection does not allow the mapping to be mutable.
+    pub fn make_mut(mut self, protection: Protection) -> Result<MmapMut> {
+        self.inner.set_protection(protection)?;
+        match protection {
+            Protection::Read | Protection::ReadExecute => Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Invalid protection for a mutable mapping",
+            )),
+            Protection::ReadWrite | Protection::ReadCopy => Ok(
+                MmapMut { inner: self.inner }
+            ),
         }
-        MmapInner::open(file, prot, 0, len as usize).map(|inner| Mmap { inner: inner })
     }
+}
 
-    /// Opens a file-backed memory map.
-    ///
-    /// The file must not be empty.
-    pub fn open_path<P>(path: P, prot: Protection) -> Result<Mmap>
-    where P: AsRef<Path> {
-        let file = try!(prot.as_open_options().open(path));
-        let len = try!(file.metadata()).len();
-        if len > usize::MAX as u64 {
-            return Err(Error::new(ErrorKind::InvalidData,
-                                  "file length overflows usize"));
+impl Deref for Mmap {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        unsafe {
+            slice::from_raw_parts(self.inner.ptr(), self.inner.len())
         }
-        MmapInner::open(&file, prot, 0, len as usize).map(|inner| Mmap { inner: inner })
     }
+}
 
-    /// Opens a file-backed memory map with the specified offset and length.
-    ///
-    /// The file must be opened with read permissions, and write permissions if
-    /// the supplied protection is `ReadWrite`. The file must not be empty. The
-    /// length must be greater than zero.
-    pub fn open_with_offset(file: &File,
-                            prot: Protection,
-                            offset: usize,
-                            len: usize) -> Result<Mmap> {
-        MmapInner::open(file, prot, offset, len).map(|inner| Mmap { inner: inner })
+impl fmt::Debug for Mmap {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Mmap {{ ptr: {:?}, len: {} }}", self.as_ptr(), self.len())
     }
+}
 
-    /// Opens an anonymous memory map.
-    ///
-    /// The length must be greater than zero.
-    pub fn anonymous(len: usize, prot: Protection) -> Result<Mmap> {
-        Mmap::anonymous_with_options(len, prot, Default::default())
-    }
+/// A mutable memory-mapped buffer.
+///
+/// A file-backed `MmapMut` buffer may be used to read or write data to a file. Use
+/// [`memmap::file(..)`](fn.file.html)`.map_mut()` to create a file-backed memory map. An anonymous
+/// `MmapMut` buffer may be used any place that an in-memory byte buffer is needed,
+/// and gives the added features of a memory map. Use
+/// [`memmap::anonymous(..)`](fn.anonymous.html)`.map_mut()`
+/// to create an anonymous memory map.
+///
+/// ```
+/// use std::io::Write;
+///
+/// let mut mmap = memmap::anonymous(4096).map_mut().unwrap();
+/// (&mut mmap[..]).write(b"foo").unwrap();
+/// assert_eq!(b"foo\0\0", &mmap[0..5]);
+/// ```
+///
+/// See [`Mmap`](struct.Mmap.html) for the immutable version.
+pub struct MmapMut {
+    inner: MmapInner
+}
 
-    /// Opens an anonymous memory map with the provided options.
-    ///
-    /// The length must be greater than zero.
-    pub fn anonymous_with_options(len: usize,
-                                  prot: Protection,
-                                  options: MmapOptions) -> Result<Mmap> {
-        MmapInner::anonymous(len, prot, options).map(|inner| Mmap { inner: inner })
-    }
-
+impl MmapMut {
     /// Flushes outstanding memory map modifications to disk.
     ///
     /// When this returns with a non-error result, all outstanding changes to a
@@ -205,69 +391,78 @@ impl Mmap {
 
     /// Change the `Protection` this mapping was created with.
     ///
-    /// If you create a read-only file-backed mapping, you can **not** use this method to make the
-    /// mapping writeable. Remap the file instead.
-    pub fn set_protection(&mut self, prot: Protection) -> Result<()> {
-        self.inner.set_protection(prot)
+    /// This method only changes the protection of the underlying mapping,
+    /// but it doesn't make an `Mmap` from an `MmapMut`, use
+    /// [`make_read_only()`](#method.make_read_only) method for that.
+    ///
+    /// # Errors
+    ///
+    /// This method returns `Err` when the underlying system call fails, which can happen for
+    /// a variety of reasons, such as when you don't have the necessary permissions for the file.
+    ///
+    /// This method *also* returns `Err` with `ErrorKind` set to `InvalidInput` if the specified
+    /// protection does not allow the mapping to be mutable.
+    pub fn set_protection(&mut self, protection: Protection) -> Result<()> {
+        match protection {
+            Protection::Read | Protection::ReadExecute => Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Invalid protection for a mutable mapping",
+            )),
+            Protection::ReadWrite | Protection::ReadCopy =>
+                self.inner.set_protection(protection),
+        }
     }
 
-    /// Returns the length of the memory map.
-    pub fn len(&self) -> usize {
-        self.inner.len()
-    }
-
-    /// Returns a pointer to the mapped memory.
+    /// Change the `Protection` this mapping was created with to make it immutable.
     ///
-    /// See `Mmap::as_slice` for invariants that must hold when dereferencing
-    /// the pointer.
-    pub fn ptr(&self) -> *const u8 {
-        self.inner.ptr()
-    }
-
-    /// Returns a pointer to the mapped memory.
+    /// # Errors
     ///
-    /// See `Mmap::as_mut_slice` for invariants that must hold when
-    /// dereferencing the pointer.
-    pub fn mut_ptr(&mut self) -> *mut u8 {
-        self.inner.mut_ptr()
-    }
-
-    /// Returns the memory mapped file as an immutable slice.
+    /// This method returns `Err` when the underlying system call fails, which can happen for
+    /// a variety of reasons, such as when you don't have the necessary permissions for the file.
     ///
-    /// ## Unsafety
-    ///
-    /// The caller must ensure that the file is not concurrently modified.
-    pub unsafe fn as_slice(&self) -> &[u8] {
-        slice::from_raw_parts(self.ptr(), self.len())
-    }
-
-    /// Returns the memory mapped file as a mutable slice.
-    ///
-    /// ## Unsafety
-    ///
-    /// The caller must ensure that the file is not concurrently accessed.
-    pub unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
-        slice::from_raw_parts_mut(self.mut_ptr(), self.len())
+    /// This method will **not** return `Err` if the passed `protection` is mutable.
+    pub fn make_read_only(mut self, protection: Protection) -> Result<Mmap> {
+        self.inner.set_protection(protection)?;
+        Ok( Mmap { inner: self.inner } )
     }
 }
 
-impl fmt::Debug for Mmap {
+impl Deref for MmapMut {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        unsafe {
+            slice::from_raw_parts(self.inner.ptr(), self.inner.len())
+        }
+    }
+}
+
+impl DerefMut for MmapMut {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        unsafe {
+            slice::from_raw_parts_mut(self.inner.mut_ptr(), self.inner.len())
+        }
+    }
+}
+
+impl fmt::Debug for MmapMut {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Mmap {{ ptr: {:?}, len: {} }}", self.ptr(), self.len())
+        write!(f, "MmapMut {{ ptr: {:?}, len: {} }}", self.as_ptr(), self.len())
     }
 }
 
 #[cfg(test)]
 mod test {
+    mod memmap {
+        pub use super::super::*;
+    }
+    use super::Protection;
+
     extern crate tempdir;
 
-    use std::{fs, iter};
+    use std::fs;
     use std::io::{Read, Write};
     use std::thread;
     use std::sync::Arc;
-    use std::ptr;
-
-    use super::*;
 
     #[test]
     fn map_file() {
@@ -275,27 +470,30 @@ mod test {
         let tempdir = tempdir::TempDir::new("mmap").unwrap();
         let path = tempdir.path().join("mmap");
 
-        fs::OpenOptions::new()
+        let file = fs::OpenOptions::new()
+                        .read(true)
                         .write(true)
                         .create(true)
-                        .open(&path).unwrap()
-                        .set_len(expected_len as u64).unwrap();
+                        .open(&path).unwrap();
 
-        let mut mmap = Mmap::open_path(path, Protection::ReadWrite).unwrap();
+        file.set_len(expected_len as u64).unwrap();
+
+        let mut mmap = unsafe { memmap::file(&file) }
+                                        .map_mut().unwrap();
         let len = mmap.len();
         assert_eq!(expected_len, len);
 
-        let zeros = iter::repeat(0).take(len).collect::<Vec<_>>();
-        let incr = (0..len).map(|n| n as u8).collect::<Vec<_>>();
+        let zeros = vec![0; len];
+        let incr: Vec<u8> = (0..len as u8).collect();
 
         // check that the mmap is empty
-        assert_eq!(&zeros[..], unsafe { mmap.as_slice() });
+        assert_eq!(&zeros[..], &mmap[..]);
 
         // write values into the mmap
-        unsafe { mmap.as_mut_slice() }.write_all(&incr[..]).unwrap();
+        (&mut mmap[..]).write_all(&incr[..]).unwrap();
 
         // read values back
-        assert_eq!(&incr[..], unsafe { mmap.as_slice() });
+        assert_eq!(&incr[..], &mmap[..]);
     }
 
     /// Checks that a 0-length file will not be mapped.
@@ -304,32 +502,33 @@ mod test {
         let tempdir = tempdir::TempDir::new("mmap").unwrap();
         let path = tempdir.path().join("mmap");
 
-        fs::OpenOptions::new()
+        let file = fs::OpenOptions::new()
+                        .read(true)
                         .write(true)
                         .create(true)
                         .open(&path).unwrap();
-
-        assert!(Mmap::open_path(path, Protection::ReadWrite).is_err());
+        let mmap = unsafe { memmap::file(&file).map() };
+        assert!(mmap.is_err());
     }
 
     #[test]
     fn map_anon() {
         let expected_len = 128;
-        let mut mmap = Mmap::anonymous(expected_len, Protection::ReadWrite).unwrap();
+        let mut mmap = memmap::anonymous(expected_len).map_mut().unwrap();
         let len = mmap.len();
         assert_eq!(expected_len, len);
 
-        let zeros = iter::repeat(0).take(len).collect::<Vec<_>>();
-        let incr = (0..len).map(|n| n as u8).collect::<Vec<_>>();
+        let zeros = vec![0; len];
+        let incr: Vec<u8> = (0..len as u8).collect();
 
         // check that the mmap is empty
-        assert_eq!(&zeros[..], unsafe { mmap.as_slice() });
+        assert_eq!(&zeros[..], &mmap[..]);
 
         // write values into the mmap
-        unsafe { mmap.as_mut_slice() }.write_all(&incr[..]).unwrap();
+        (&mut mmap[..]).write_all(&incr[..]).unwrap();
 
         // read values back
-        assert_eq!(&incr[..], unsafe { mmap.as_slice() });
+        assert_eq!(&incr[..], &mmap[..]);
     }
 
     #[test]
@@ -347,8 +546,9 @@ mod test {
         let write = b"abc123";
         let mut read = [0u8; 6];
 
-        let mut mmap = Mmap::open_path(&path, Protection::ReadWrite).unwrap();
-        unsafe { mmap.as_mut_slice() }.write_all(write).unwrap();
+        let mut mmap = unsafe { memmap::file(&file) }
+                                        .map_mut().unwrap();
+        (&mut mmap[..]).write_all(write).unwrap();
         mmap.flush().unwrap();
 
         file.read(&mut read).unwrap();
@@ -368,8 +568,11 @@ mod test {
         file.set_len(128).unwrap();
         let write = b"abc123";
 
-        let mut mmap = Mmap::open_with_offset(&file, Protection::ReadWrite, 2, write.len()).unwrap();
-        unsafe { mmap.as_mut_slice() }.write_all(write).unwrap();
+        let mut mmap = unsafe { memmap::file(&file) }
+                                .offset(2)
+                                .len(write.len())
+                                .map_mut().unwrap();
+        (&mut mmap[..]).write_all(write).unwrap();
         mmap.flush_range(0, write.len()).unwrap();
     }
 
@@ -389,12 +592,15 @@ mod test {
         let write = b"abc123";
         let mut read = [0u8; 6];
 
-        let mut mmap = Mmap::open_path(&path, Protection::ReadCopy).unwrap();
-        unsafe { mmap.as_mut_slice() }.write(write).unwrap();
+        let mut mmap = unsafe { memmap::file(&file) }
+                                .protection(Protection::ReadCopy)
+                                .map_mut().unwrap();
+
+        (&mut mmap[..]).write(write).unwrap();
         mmap.flush().unwrap();
 
         // The mmap contains the write
-        unsafe { mmap.as_slice() }.read(&mut read).unwrap();
+        (&mmap[..]).read(&mut read).unwrap();
         assert_eq!(write, &read);
 
         // The file does not contain the write
@@ -402,8 +608,9 @@ mod test {
         assert_eq!(nulls, &read);
 
         // another mmap does not contain the write
-        let mmap2 = Mmap::open_path(&path, Protection::Read).unwrap();
-        unsafe { mmap2.as_slice() }.read(&mut read).unwrap();
+        let mmap2 = unsafe { memmap::file(&file) }
+                                    .map().unwrap();
+        (&mmap2[..]).read(&mut read).unwrap();
         assert_eq!(nulls, &read);
     }
 
@@ -424,53 +631,38 @@ mod test {
         let offset = 5099;
         let len = 50050;
 
-        let mut mmap = Mmap::open_with_offset(&file,
-                                              Protection::ReadWrite,
-                                              offset,
-                                              len).unwrap();
+        let mut mmap = unsafe { memmap::file(&file) }
+                                .offset(offset)
+                                .len(len)
+                                .map_mut().unwrap();
         assert_eq!(len, mmap.len());
 
-        let zeros = iter::repeat(0).take(len).collect::<Vec<_>>();
-        let incr = (0..len).map(|n| n as u8).collect::<Vec<_>>();
+        let zeros = vec![0; len];
+        let incr: Vec<_> = (0..len).map(|i| i as u8).collect();
 
         // check that the mmap is empty
-        assert_eq!(&zeros[..], unsafe { mmap.as_slice() });
+        assert_eq!(&zeros[..], &mmap[..]);
 
         // write values into the mmap
-        unsafe { mmap.as_mut_slice() }.write_all(&incr[..]).unwrap();
+        (&mut mmap[..]).write_all(&incr[..]).unwrap();
 
         // read values back
-        assert_eq!(&incr[..], unsafe { mmap.as_slice() });
+        assert_eq!(&incr[..], &mmap[..]);
     }
 
     #[test]
     fn index() {
-        let mut mmap = Mmap::anonymous(128, Protection::ReadWrite).unwrap();
-        unsafe { mmap.as_mut_slice()[0] = 42 };
-        assert_eq!(42, unsafe { mmap.as_slice()[0] });
+        let mut mmap = memmap::anonymous(128).map_mut().unwrap();
+        mmap[0] = 42;
+        assert_eq!(42, mmap[0]);
     }
 
     #[test]
     fn sync_send() {
-        let mmap = Arc::new(Mmap::anonymous(128, Protection::ReadWrite).unwrap());
+        let mmap = Arc::new(memmap::anonymous(128).map_mut().unwrap());
         thread::spawn(move || {
-            unsafe {
-                mmap.as_slice();
-            }
+            &mmap[..];
         });
-    }
-
-    #[test]
-    fn set_prot() {
-        let mut map = Mmap::anonymous(1, Protection::Read).unwrap();
-        map.set_protection(Protection::ReadWrite).unwrap();
-
-        // We should now be able to write to the memory. If not this will cause a SIGSEGV.
-        unsafe { ptr::write(map.mut_ptr(), 0xf1); }
-
-        map.set_protection(Protection::Read).unwrap();
-
-        assert_eq!(unsafe { ptr::read(map.mut_ptr()) }, 0xf1);
     }
 
     #[test]
@@ -478,21 +670,18 @@ mod test {
     fn jit_x86() {
         use std::mem;
 
-        let mut map = Mmap::anonymous(4096, Protection::ReadWrite).unwrap();
+        let mut mmap = memmap::anonymous(4096).map_mut().unwrap();
 
-        {
-            let mut jitmem = unsafe { map.as_mut_slice() };
-            jitmem[0] = 0xB8;   // mov eax, 0xAB
-            jitmem[1] = 0xAB;
-            jitmem[2] = 0x00;
-            jitmem[3] = 0x00;
-            jitmem[4] = 0x00;
-            jitmem[5] = 0xC3;   // ret
-        }
+        mmap[0] = 0xB8;   // mov eax, 0xAB
+        mmap[1] = 0xAB;
+        mmap[2] = 0x00;
+        mmap[3] = 0x00;
+        mmap[4] = 0x00;
+        mmap[5] = 0xC3;   // ret
 
-        map.set_protection(Protection::ReadExecute).unwrap();
+        let mmap = mmap.make_read_only(Protection::ReadExecute).unwrap();
 
-        let jitfn: extern "C" fn() -> u8 = unsafe { mem::transmute(map.mut_ptr()) };
+        let jitfn: extern "C" fn() -> u8 = unsafe { mem::transmute(mmap.as_ptr()) };
         assert_eq!(jitfn(), 0xab);
     }
 
@@ -512,26 +701,25 @@ mod test {
 
         let offset = 5099;
         let len = 50050;
-
-        let mut mmap = Mmap::open_with_offset(&file,
-                                              Protection::ReadWrite,
-                                              offset,
-                                              len).unwrap();
+        let mut mmap = unsafe { memmap::file(&file) }
+                                .offset(offset)
+                                .len(len)
+                                .map_mut().unwrap();
         assert_eq!(len, mmap.len());
 
-        let zeros = iter::repeat(0).take(len).collect::<Vec<_>>();
-        let incr = (0..len).map(|n| n as u8).collect::<Vec<_>>();
+        let zeros = vec![0; len];
+        let incr: Vec<_> = (0..len).map(|i| i as u8).collect();
 
         // check that the mmap is empty
-        assert_eq!(&zeros[..], unsafe { mmap.as_slice() });
+        assert_eq!(&zeros[..], &mmap[..]);
 
         // write values into the mmap
-        unsafe { mmap.as_mut_slice() }.write_all(&incr[..]).unwrap();
+        (&mut mmap[..]).write_all(&incr[..]).unwrap();
 
         // change to read-only protection
-        mmap.set_protection(Protection::Read).unwrap();
+        let mmap = mmap.make_read_only(Protection::Read).unwrap();
 
         // read values back
-        assert_eq!(&incr[..], unsafe { mmap.as_slice() });
+        assert_eq!(&incr[..], &mmap[..]);
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -10,7 +10,6 @@ use std::os::windows::io::AsRawHandle;
 use self::fs2::FileExt;
 
 use ::Protection;
-use ::MmapOptions;
 
 impl Protection {
 
@@ -78,13 +77,7 @@ impl MmapInner {
         }
     }
 
-    /// Check if a file needs to be writable for copy-on-write mode.
-    #[inline]
-    pub fn needs_write_for_copy() -> bool {
-        true
-    }
-
-    pub fn anonymous(len: usize, prot: Protection, _options: MmapOptions) -> io::Result<MmapInner> {
+    pub fn anonymous(len: usize, prot: Protection, _stack: bool) -> io::Result<MmapInner> {
         unsafe {
             // Create a mapping and view with maximum access permissions, then use `VirtualProtect`
             // to set the actual `Protection`. This way, we can set more permissive protection later


### PR DESCRIPTION
Overhaul the API as requested in #33. In particular,
* Remove `MmapView` and `MmapViewSync` types
* Define two types - `Mmap` and `MmapMut` for readable and readable/writable mappings respectively. They implement `Deref<Target = [u8]>`/`DerefMut` as appropriate.
    * `Mmap` has no `flush` methods.
    * Alongside "raw" `set_protection()`, provide `make_mut()` and `make_read_only()` to safely convert between `Mmap` and `MmapMut`.
* Get rid of multiple `open`, `open_path`, `anonymous_with_options`, ... methods. Instead, provide two `OpenOptions`-style builders, one for file-backed and one for anonymous mappings.
    * Remove support for opening files by their path. Always use `std::fs::File`.
    * On Unix, `memmap::file()` is `unsafe`. This seems to be the best approach, although it is always safe to use it with `ReadCopy`.
    * To improve ergonomics, automatically pick a suitable `Protection` unless specified explicitly.
        * This makes it ergonomic enough so there's no need for additional convenience constructors.
* Convert the tests and the cat example to use the new API.
    * `use super as memmap` doesn't seem to work, rustc says that `super` is not found because it's the root module, WTF? Yet, `use super::*` works. Check out the workaround I came up with.