### PR TITLE
Add madvise wrapper

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -4,10 +4,19 @@ use std::{io, ptr};
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
 
-use ::Protection;
+use Protection;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum AccessPattern {
+    Normal = libc::MADV_NORMAL,
+    Sequential = libc::MADV_SEQUENTIAL,
+    Random = libc::MADV_RANDOM,
+    DontNeed = libc::MADV_DONTNEED,
+    WillNeed = libc::MADV_WILLNEED,
+}
 
 impl Protection {
-
     /// Returns the `Protection` value as a POSIX protection flag.
     fn as_prot(self) -> libc::c_int {
         match self {
@@ -126,6 +135,22 @@ impl MmapInner {
             Ok(())
         } else {
             Err(io::Error::last_os_error())
+        }
+    }
+
+    pub fn advise(&self, offset: usize, len: usize, advice: AccessPattern) -> io::Result<()> {
+        unsafe {
+            let result = libc::madvise(
+                self.ptr().offset(offset as _) as *mut libc::c_void,
+                len as _,
+                advice as libc::c_int,
+            );
+
+            if result == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
         }
     }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -141,8 +141,8 @@ impl MmapInner {
     pub fn advise(&self, offset: usize, len: usize, advice: AccessPattern) -> io::Result<()> {
         unsafe {
             let result = libc::madvise(
-                self.ptr().offset(offset as _) as *mut libc::c_void,
-                len as _,
+                self.ptr().offset(offset as isize) as *mut libc::c_void,
+                len as libc::size_t,
                 advice as libc::c_int,
             );
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -9,10 +9,18 @@ use std::os::windows::io::AsRawHandle;
 
 use self::fs2::FileExt;
 
-use ::Protection;
+use Protection;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AccessPattern {
+    Normal,
+    Sequential,
+    Random,
+    DontNeed,
+    WillNeed,
+}
 
 impl Protection {
-
     /// Returns the `Protection` as a flag appropriate for a call to `CreateFileMapping`.
     fn as_mapping_flag(self) -> winapi::DWORD {
         match self {
@@ -135,6 +143,10 @@ impl MmapInner {
         } else {
             Err(io::Error::last_os_error())
         }
+    }
+
+    pub fn advise(&self, offset: usize, len: usize, advice: AccessPattern) -> io::Result<()> {
+        Ok(())
     }
 
     pub fn set_protection(&mut self, prot: Protection) -> io::Result<()> {


### PR DESCRIPTION
This doesn't have docs for `AccessPattern` yet and hasn't been properly tested, but it's a start. Worth getting some critique early. It also explicitly only implements the POSIX `madvise` flags instead of including the Linux extensions, although that would definitely be a good thing to add.