### PR TITLE
Inline deref codepath methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,6 +389,8 @@ impl Mmap {
 
 impl Deref for Mmap {
     type Target = [u8];
+
+    #[inline]
     fn deref(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.inner.ptr(), self.inner.len()) }
     }
@@ -592,12 +594,15 @@ impl MmapMut {
 
 impl Deref for MmapMut {
     type Target = [u8];
+
+    #[inline]
     fn deref(&self) -> &[u8] {
         unsafe { slice::from_raw_parts(self.inner.ptr(), self.inner.len()) }
     }
 }
 
 impl DerefMut for MmapMut {
+    #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
         unsafe { slice::from_raw_parts_mut(self.inner.mut_ptr(), self.inner.len()) }
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -168,14 +168,17 @@ impl MmapInner {
         self.mprotect(libc::PROT_READ | libc::PROT_WRITE)
     }
 
+    #[inline]
     pub fn ptr(&self) -> *const u8 {
         self.ptr as *const u8
     }
 
+    #[inline]
     pub fn mut_ptr(&mut self) -> *mut u8 {
         self.ptr as *mut u8
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -244,14 +244,17 @@ impl MmapInner {
         }
     }
 
+    #[inline]
     pub fn ptr(&self) -> *const u8 {
         self.ptr as *const u8
     }
 
+    #[inline]
     pub fn mut_ptr(&mut self) -> *mut u8 {
         self.ptr as *mut u8
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.len
     }


### PR DESCRIPTION
No need for a function call every time we deref!