### PR TITLE
Documentation improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,10 +285,10 @@ impl MmapOptions {
 /// An immutable memory mapped buffer.
 ///
 /// A `Mmap` may be backed by a file, or it can be anonymous map, backed by volatile memory.
+/// Use [`MmapOptions`](struct.MmapOptions.html) or [`map`](#method.map) to create a file-backed
+/// memory map. To create an immutable anonymous memory map, first create a mutable anonymous
+/// memory map using `MmapOptions`, and then make it immutable with `MmapMut::make_read_only`.
 ///
-/// Use [`MmapOptions`](struct.MmapOptions.html) to configure and create a file-backed memory
-/// map. To create an immutable anonymous memory map, first create a mutable anonymous memory map
-/// using `MmapOptions`, and then make it immutable with `MmapMut::make_read_only`.
 ///
 /// # Example
 ///
@@ -419,7 +419,8 @@ impl fmt::Debug for Mmap {
 ///
 /// A file-backed `MmapMut` buffer may be used to read from or write to a file. An anonymous
 /// `MmapMut` buffer may be used any place that an in-memory byte buffer is needed. Use
-/// [`MmapOptions`](struct.MmapOptions.html) for creating memory maps.
+/// [`MmapOptions`](struct.MmapOptions.html), [`map_mut`](#method.map_mut) or
+/// [`map_anon`](#method.map_anon) to create a mutable memory map.
 ///
 /// See [`Mmap`](struct.Mmap.html) for the immutable version.
 pub struct MmapMut {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,9 +285,9 @@ impl MmapOptions {
 ///
 /// A `Mmap` may be backed by a file, or it can be anonymous map, backed by volatile memory.
 ///
-/// Use `MmapOptions` to configure and create a file-backed memory map. To create an immutable
-/// anonymous memory map, first create a mutable anonymous memory map using `MmapOptions`, and then
-/// make it immutable with `MmapMut::make_read_only`.
+/// Use [`MmapOptions`](struct.MmapOptions.html) to configure and create a file-backed memory
+/// map. To create an immutable anonymous memory map, first create a mutable anonymous memory map
+/// using `MmapOptions`, and then make it immutable with `MmapMut::make_read_only`.
 ///
 /// # Example
 ///
@@ -305,7 +305,7 @@ impl MmapOptions {
 /// # fn main() { try_main().unwrap(); }
 /// ```
 ///
-/// See `MmapMut` for the mutable version.
+/// See [`MmapMut`](struct.MmapMut.html) for the mutable version.
 pub struct Mmap {
     inner: MmapInner,
 }
@@ -418,9 +418,9 @@ impl fmt::Debug for Mmap {
 ///
 /// A file-backed `MmapMut` buffer may be used to read from or write to a file. An anonymous
 /// `MmapMut` buffer may be used any place that an in-memory byte buffer is needed. Use
-/// `MmapOptions` for creating memory maps.
+/// [`MmapOptions`](struct.MmapOptions.html) for creating memory maps.
 ///
-/// See `Mmap` for the immutable version.
+/// See [`Mmap`](struct.Mmap.html) for the immutable version.
 pub struct MmapMut {
     inner: MmapInner,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,8 +297,8 @@ impl MmapOptions {
 /// Dereferencing and accessing the bytes of the buffer may result in page faults (e.g. swapping
 /// the mapped pages into physical memory) though the details of this are platform specific.
 ///
-/// `Mmap` is `Sync` and `Send`. You may use `Arc<Mmap>` for a shared, reference counted
-/// handle.
+/// `Mmap` is `Sync` and `Send`. For a shared, reference counted handle, you may use `Rc<Mmap>`, or
+/// to preserve `Sync` and `Send`, use `Arc<Mmap>`.
 ///
 /// # Example
 ///
@@ -440,8 +440,8 @@ impl fmt::Debug for Mmap {
 /// Dereferencing and accessing the bytes of the buffer may result in page faults (e.g. swapping
 /// the mapped pages into physical memory) though the details of this are platform specific.
 ///
-/// `MmapMut` is `Sync` and `Send`. You may use `Arc<MmapMut>` for a shared, reference counted
-/// handle.
+/// `MmapMut` is `Sync` and `Send`. For a shared handle supporting mutable access, consider using
+/// `Mutex<MmapMut>` or `RwLock<MmapMut>`.
 ///
 /// See [`Mmap`](struct.Mmap.html) for the immutable version.
 pub struct MmapMut {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,13 +282,23 @@ impl MmapOptions {
     }
 }
 
-/// An immutable memory mapped buffer.
+/// A handle to an immutable memory mapped buffer.
 ///
 /// A `Mmap` may be backed by a file, or it can be anonymous map, backed by volatile memory.
 /// Use [`MmapOptions`](struct.MmapOptions.html) or [`map`](#method.map) to create a file-backed
 /// memory map. To create an immutable anonymous memory map, first create a mutable anonymous
 /// memory map using `MmapOptions`, and then make it immutable with `MmapMut::make_read_only`.
 ///
+/// A file backed `Mmap` is created by `&File` reference, and will remain valid even after the
+/// `File` is dropped. In other words, the `Mmap` handle is completely independent of the `File`
+/// used to create it. For consistency, on some platforms this is achieved by duplicating the
+/// underlying file handle. The memory will be unmapped when the `Mmap` handle is dropped.
+///
+/// Dereferencing and accessing the bytes of the buffer may result in page faults (e.g. swapping
+/// the mapped pages into physical memory) though the details of this are platform specific.
+///
+/// `Mmap` is `Sync` and `Send`. You may use `Arc<Mmap>` for a shared, reference counted
+/// handle.
 ///
 /// # Example
 ///
@@ -415,12 +425,23 @@ impl fmt::Debug for Mmap {
     }
 }
 
-/// A mutable memory mapped buffer.
+/// A handle to a mutable memory mapped buffer.
 ///
 /// A file-backed `MmapMut` buffer may be used to read from or write to a file. An anonymous
 /// `MmapMut` buffer may be used any place that an in-memory byte buffer is needed. Use
 /// [`MmapOptions`](struct.MmapOptions.html), [`map_mut`](#method.map_mut) or
 /// [`map_anon`](#method.map_anon) to create a mutable memory map.
+///
+/// A file backed `MmapMut` is created by `&File` reference, and will remain valid even after the
+/// `File` is dropped. In other words, the `MmapMut` handle is completely independent of the `File`
+/// used to create it. For consistency, on some platforms this is achieved by duplicating the
+/// underlying file handle. The memory will be unmapped when the `MmapMut` handle is dropped.
+///
+/// Dereferencing and accessing the bytes of the buffer may result in page faults (e.g. swapping
+/// the mapped pages into physical memory) though the details of this are platform specific.
+///
+/// `MmapMut` is `Sync` and `Send`. You may use `Arc<MmapMut>` for a shared, reference counted
+/// handle.
 ///
 /// See [`Mmap`](struct.Mmap.html) for the immutable version.
 pub struct MmapMut {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,14 @@ use std::usize;
 /// [`map_anon`](#method.map_anon),
 /// or a file-backed memory map using one of [`map`](#method.map), [`map_mut`](#method.map_mut),
 /// [`map_exec`](#method.map_exec), or [`map_copy`](#method.map_copy).
+///
+/// ## Safety
+///
+/// All file-backed memory map constructors are marked `unsafe` because of the potential for
+/// *Undefined Behavior* (UB) using the map if the underlying file is subsequently modified, in or
+/// out of process.  Applications must consider the risk and take appropriate precautions when
+/// using file-backed maps. Solutions such as file permissions, locks or process-private
+/// (e.g. unlinked) files exist but are platform specific and limited.
 #[derive(Clone, Debug, Default)]
 pub struct MmapOptions {
     offset: u64,
@@ -293,7 +301,15 @@ impl MmapOptions {
 /// `Mmap` is `Sync` and `Send`. For a shared, reference counted handle, you may use `Rc<Mmap>`, or
 /// to preserve `Sync` and `Send`, use `Arc<Mmap>`.
 ///
-/// # Example
+/// ## Safety
+///
+/// All file-backed memory map constructors are marked `unsafe` because of the potential for
+/// *Undefined Behavior* (UB) using the map if the underlying file is subsequently modified, in or
+/// out of process.  Applications must consider the risk and take appropriate precautions when
+/// using file-backed maps. Solutions such as file permissions, locks or process-private
+/// (e.g. unlinked) files exist but are platform specific and limited.
+///
+/// ## Example
 ///
 /// ```
 /// use memmap::MmapOptions;
@@ -434,6 +450,14 @@ impl fmt::Debug for Mmap {
 /// `Mutex<MmapMut>` or `RwLock<MmapMut>`.
 ///
 /// See [`Mmap`](struct.Mmap.html) for the immutable version.
+///
+/// ## Safety
+///
+/// All file-backed memory map constructors are marked `unsafe` because of the potential for
+/// *Undefined Behavior* (UB) using the map if the underlying file is subsequently modified, in or
+/// out of process.  Applications must consider the risk and take appropriate precautions when
+/// using file-backed maps. Solutions such as file permissions, locks or process-private
+/// (e.g. unlinked) files exist but are platform specific and limited.
 pub struct MmapMut {
     inner: MmapInner,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,10 @@ use std::ops::{Deref, DerefMut};
 
 /// A memory map builder, providing advanced options and flags for specifying memory map behavior.
 ///
-/// `MmapOptions` can be used to create an anonymous memory map using `MmapOptions::map_anon`, or a
-/// file-backed memory map using one of `MmapOptions::map`, `MmapOptions::map_mut`,
-/// `MmapOptions::map_exec`, or `MmapOptions::map_copy`.
+/// `MmapOptions` can be used to create an anonymous memory map using
+/// [`map_anon`](#method.map_anon),
+/// or a file-backed memory map using one of [`map`](#method.map), [`map_mut`](#method.map_mut),
+/// [`map_exec`](#method.map_exec), or [`map_copy`](#method.map_copy).
 #[derive(Clone, Debug, Default)]
 pub struct MmapOptions {
     offset: usize,


### PR DESCRIPTION
I've had my share of doubts on correct usage of _memmap-rs_, many of which I was eventually able to clear up by searching the github issues and PR's merged or closed.   In this PR I attempt to document some basics that I hope are non-controversial and specific to the rust wrapping.  Some of the changes are just rustdoc niceties like links.

This [comment](https://github.com/danburkert/memmap-rs/issues/49#issuecomment-319233236) in #49 was super helpful to me, and I've tried to restate it here in terms of relative lifetimes. 

The unmerged `try_clone` part of #61 prompted me to try using `Arc<Mmap>`, and I've mentioned that usage in the doc, as I think it can add clarity around possible threaded access and lifetime. 

This likely only addresses a small fraction of what was requested in #47, but is it not a worthy improvement?