### PR TITLE
avoid silently truncating the offset

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -44,7 +44,7 @@ impl MmapInner {
                 "memory map must have a non-zero length",
             ));
         }
-        let max_offset: libc::off_t = !0;
+        let max_offset = libc::off_t::max_value();
         if offset > max_offset as u64 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -44,6 +44,13 @@ impl MmapInner {
                 "memory map must have a non-zero length",
             ));
         }
+        let max_offset: libc::off_t = !0;
+        if offset > max_offset as u64 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "offset overflows libc::off_t",
+            ));
+        }
 
         unsafe {
             let ptr = libc::mmap(


### PR DESCRIPTION
This should address one of the concerns that came up in https://github.com/danburkert/memmap-rs/pull/65.

I'm not sure exactly what test I should add for this case. Please advise :)