### PR TITLE
Use custom bindings instead of winapi crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,5 @@ appveyor = { repository = "danburkert/mmap" }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["basetsd", "handleapi", "memoryapi", "minwindef", "std", "sysinfoapi"] }
-
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 #![doc(html_root_url = "https://docs.rs/memmap/0.7.0")]
 
 #[cfg(windows)]
-extern crate winapi;
-#[cfg(windows)]
 mod windows;
 #[cfg(windows)]
 use windows::MmapInner;
@@ -683,8 +681,6 @@ impl fmt::Debug for MmapMut {
 mod test {
 
     extern crate tempdir;
-    #[cfg(windows)]
-    extern crate winapi;
 
     use std::fs::OpenOptions;
     use std::io::{Read, Write};
@@ -694,7 +690,7 @@ mod test {
     use std::thread;
 
     #[cfg(windows)]
-    use winapi::um::winnt::GENERIC_ALL;
+    const GENERIC_ALL: u32 = 0x10000000;
 
     use super::{Mmap, MmapMut, MmapOptions};
 


### PR DESCRIPTION
The `winapi` crate requires `winapi-*-pc-windows-gnu` crates, which are pretty heavy (100MB). This blow ups the vendored archives size. Which is important for such a widely used crate.

There are only two ways to fix this:

- Wait for https://github.com/rust-lang/rust/issues/58713, but looks like it will not be fixed anytime soon.
- Use custom bindings (we need like 5 methods anyway).

This patch doesn't make this library less safe since `winapi` crate doesn't contain any logic. We simply copy-pasting `winapi` crate definitions.

This patch doesn't break comparability/api since it affects only the internal implementation.

The only remaining question is portability. The `winapi` crate does a lot of linking magic, but I'm not sure if we need it at all. **UPD** since all tests are passed, looks like we don't need it anyway.