### PR TITLE
Why is map_anon MAP_SHARED?

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -112,7 +112,7 @@ impl MmapInner {
         MmapInner::new(
             len,
             libc::PROT_READ | libc::PROT_WRITE,
-            libc::MAP_SHARED | libc::MAP_ANON | stack,
+            libc::MAP_PRIVATE | libc::MAP_ANON | stack,
             -1,
             0,
         )


### PR DESCRIPTION
OK now that I've had some sleep: map_anon implies map_private, there's nothing to share. Having map_shared enabled on the map_anon call was tripping miri.